### PR TITLE
Fix impossible highlight query for Compact function calls

### DIFF
--- a/languages/compact/highlights.scm
+++ b/languages/compact/highlights.scm
@@ -112,7 +112,12 @@
 (gargs (_) @type.parameter)
 (struct_named_filed_initializer (id) @field)
 (pattern_struct_elt (id) @field)
-(term (expr "." (id) @function.call (expr) @parameter))
+(function_call_term
+  fun: (fun (id) @function.call)
+  expr: (expr) @parameter)
+(member_access_expr
+  member: (id) @function.call
+  expr: (expr) @parameter)
 
 ; Function Definitions and Calls
 (cdefn (function_name) @function)


### PR DESCRIPTION
# Overview

Fixes an invalid Compact highlights query that prevents the language from loading in Zed.

The previous query attempted to match function/member calls using this shape:

```scheme
(term (expr "." (id) @function.call (expr) @parameter))
```

That pattern is impossible for the current grammar. Function calls and member calls are represented by named grammar nodes instead:

- `function_call_term`
- `member_access_expr`

This updates the highlight query to match those actual node shapes.

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (if possible)
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [x] Update README.md file (if relevant)
- [x] Update documentation (if relevant)
- [x] No new todos introduced

## Verification

```sh
cargo fmt --all
PATH="$HOME/.cargo/bin:$PATH" cargo build --target=wasm32-wasip1
PATH="$HOME/.cargo/bin:$PATH" cargo clippy --target=wasm32-wasip1 --all-targets --all-features
HOME=/tmp tree-sitter query --quiet --grammar-path grammars/compact languages/compact/highlights.scm grammars/compact/test/corpus/circuit.txt
HOME=/tmp tree-sitter query --quiet --grammar-path grammars/compact languages/compact/highlights.scm grammars/compact/test/corpus/statements.txt
```

## Links

Closes #29
